### PR TITLE
Replace caBundle by the gen-certs.sh

### DIFF
--- a/dev/gen-certs.sh
+++ b/dev/gen-certs.sh
@@ -29,4 +29,8 @@ echo
 echo ">> MutatingWebhookConfiguration caBundle:"
 cat ca.crt | base64 | fold
 
+export CACERT=$(cat ca.crt | base64)
+yq eval '.webhooks[0].clientConfig.caBundle= env(CACERT)' -i manifests/cluster-config/validating.config.yaml
+yq eval '.webhooks[0].clientConfig.caBundle= env(CACERT)' -i manifests/cluster-config/mutating.config.yaml
+
 rm ca.crt ca.key ca.srl server.crt server.csr server.key


### PR DESCRIPTION
Signed-off-by: Fynn Späker <spaeker@23technologies.cloud>

###  Summary

At the moment the `gen-certs.sh` script only manipulates the `gen/manifests/webhook/webhook.tls.secret.yaml` file. 
But we also have to manipulate the webhook resources. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/simple-kubernetes-webhook/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/simple-kubernetes-webhook).
