### PR TITLE
Generate self-sign cert with SHA256

### DIFF
--- a/dev/gen-certs.sh
+++ b/dev/gen-certs.sh
@@ -2,7 +2,7 @@
 
 openssl genrsa -out ca.key 2048
 
-openssl req -new -x509 -days 365 -key ca.key \
+openssl req -new -x509 -days 365 -sha256 -key ca.key \
   -subj "/C=AU/CN=simple-kubernetes-webhook"\
   -out ca.crt
 
@@ -10,7 +10,7 @@ openssl req -newkey rsa:2048 -nodes -keyout server.key \
   -subj "/C=AU/CN=simple-kubernetes-webhook" \
   -out server.csr
 
-openssl x509 -req \
+openssl x509 -req -sha256 \
   -extfile <(printf "subjectAltName=DNS:simple-kubernetes-webhook.default.svc") \
   -days 365 \
   -in server.csr \


### PR DESCRIPTION
###  Summary

When apply a pod, I faced this error.
```sh
$ kubectl -n $ns apply -f dev/manifests/pods/bad-name.pod.yaml
Error from server (InternalError): error when creating "dev/manifests/pods/bad-name.pod.yaml": Internal error occurred: failed calling webhook "simple-kubernetes-webhook.acme.com": failed to call webhook: Post "https://simple-kubernetes-webhook.default.svc:443/mutate-pods?timeout=2s": x509: certificate signed by unknown authority (possibly because of "x509: cannot verify signature: insecure algorithm SHA1-RSA (temporarily override with GODEBUG=x509sha1=1)" while trying to verify candidate authority certificate "simple-kubernetes-webhook")
```

The cert used the insecure algorithm SHA1-RSA.
That will be blocked by crypto/x509. https://github.com/golang/go/issues/41682

### Requirements (place an `x` in each `[ ]`)

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/simple-kubernetes-webhook/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [ ] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/simple-kubernetes-webhook).
